### PR TITLE
Add `sysname` to `snmpd.conf`

### DIFF
--- a/data/run.sh
+++ b/data/run.sh
@@ -5,6 +5,7 @@ CONFIG="/etc/snmp/snmpd.conf"
 
 {
 	echo "com2sec readonly default $(bashio::config 'community')"
+	echo "sysname $(bashio::config 'sysname')"
 	echo "syslocation $(bashio::config 'location')"
 	echo "syscontact $(bashio::config 'name') <$(bashio::config 'email')>"
 	echo "group MyROGroup v2c readonly"


### PR DESCRIPTION
Add `sysname` to `snmpd.conf`. It's already in the Addon configuration, but was not added to actual snmpd config.

Fixes https://github.com/PecceG2/Home-Assistant-SNMP-Sensor-Server/issues/11